### PR TITLE
Fix "This container does not reference a native unsigned integer"

### DIFF
--- a/lib/PDF/IO/Filter/RunLength.rakumod
+++ b/lib/PDF/IO/Filter/RunLength.rakumod
@@ -14,7 +14,7 @@ class PDF::IO::Filter::RunLength {
         my int $j = 0;
 
         while $i <= n {
-            my int $ind = 0;
+            my uint $ind = 0;
             my $ind-pos = $j++;
             my \ord = input[$i++];
             @out[$j++] = ord;


### PR DESCRIPTION
The value one assigns to a uint array slot must be unsigned. This did not throw
an error before, because Rakudo treated int and uint mostly the same. Now that
this is fixed in Rakudo, the bug in PDF::IO::Filter::RunLength surfaced. The fix
is backwards compatible (again because old Rakudo didn't care about int/uint).